### PR TITLE
Corrections in `condition_missing()`, `check_missing()`, and `bang_not_tilde()`

### DIFF
--- a/src/stata_linter_detect.py
+++ b/src/stata_linter_detect.py
@@ -192,7 +192,7 @@ def condition_missing(
     ):
 
     # warn if "var < ." or "var != ." are used
-    if re.search(r"(<|!=)( )*(\.(?![0-9]))", line):
+    if re.search(r"(<|!=|~=)( )*(\.(?![0-9]))", line):
         print_output = (
             '''Use "!missing(var)" instead of "var < ." or "var != .".'''
             )

--- a/src/stata_linter_detect.py
+++ b/src/stata_linter_detect.py
@@ -192,7 +192,7 @@ def condition_missing(
     ):
 
     # warn if "var < ." or "var != ." are used
-    if re.search(r"(<|!=)( )*\.", line):
+    if re.search(r"(<|!=)( )*(\.(?![0-9]))", line):
         print_output = (
             '''Use "!missing(var)" instead of "var < ." or "var != .".'''
             )

--- a/src/stata_linter_detect.py
+++ b/src/stata_linter_detect.py
@@ -194,7 +194,7 @@ def condition_missing(
     # warn if "var < ." or "var != ." are used
     if re.search(r"(<|!=|~=)( )*(\.(?![0-9]))", line):
         print_output = (
-            '''Use "!missing(var)" instead of "var < ." or "var != .".'''
+            '''Use "!missing(var)" instead of "var < ." or "var != ."'''
             )
         if suppress != "1":
             print(
@@ -339,7 +339,7 @@ def check_missing(
     tab_space
     ):
     # ask if missing variables are properly taken into account
-    if re.search(r"(~=)|(!=)(?!(( )*\.))", line):
+    if re.search(r"(~=|!=)(?! *\.(?![0-9]))", line):
         print_output = (
             '''Are you taking missing values into account properly? ''' +
             '''(Remember that "a != 0" includes cases where a is missing.)'''

--- a/src/stata_linter_detect.py
+++ b/src/stata_linter_detect.py
@@ -385,7 +385,7 @@ def bang_not_tilde(
 
     # warn if tilde is used, which suggests
     # that the user may be using tilde for negation
-    if re.search(r"~", line):
+    if re.search(r"~=\s*([^\s.]|\.[0-9]+)", line):
         print_output = (
             '''Are you using tilde (~) for negation? ''' +
             '''If so, for negation, use bang (!) instead of tilde (~).'''

--- a/src/stata_linter_detect.py
+++ b/src/stata_linter_detect.py
@@ -194,7 +194,7 @@ def condition_missing(
     # warn if "var < ." or "var != ." are used
     if re.search(r"(<|!=|~=)( )*(\.(?![0-9]))", line):
         print_output = (
-            '''Use "!missing(var)" instead of "var < ." or "var != ."'''
+            '''Use "!missing(var)" instead of "var < ." or "var != ." or "var ~= ."'''
             )
         if suppress != "1":
             print(


### PR DESCRIPTION
Changes:

- Added "dot not followed by a number" in regex for `condition_missing()`
- Added "~=" in non-equality symbols of `condition_missing()`
- Excluded "dot followed by a number" in `check_missing()` regex
- Added 'or "var ~= ."' in verbose warning message of `condition_missing()`
- Excluded missing checks ("~= .") from `bang_not_tilde()`

Solves #38 