### PR TITLE
ci: bump github actions versions

### DIFF
--- a/.github/workflows/python_test.yaml
+++ b/.github/workflows/python_test.yaml
@@ -3,10 +3,10 @@ name: Python package
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   build:

--- a/.github/workflows/python_test.yaml
+++ b/.github/workflows/python_test.yaml
@@ -17,9 +17,9 @@ jobs:
         python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -39,7 +39,7 @@ jobs:
         run: |
           pytest --doctest-modules --junitxml=junit/test-results-${{ matrix.python-version }}.xml
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1
+        uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:
           files: junit/test-results-*.xml


### PR DESCRIPTION
Hello, this is my first PR to the project.

It just bumps the github actions versions.

I just realized: You have the .github/workflows directory. But did you enable CI?
There seems to be no https://github.com/worldbank/stata-linter/actions